### PR TITLE
Fix renderer config on linear manhattan display

### DIFF
--- a/config.json
+++ b/config.json
@@ -61,6 +61,37 @@
           "type": "LinearManhattanDisplay"
         }
       ]
+    },
+    {
+      "type": "FeatureTrack",
+      "trackId": "gwas_track_custom_color",
+      "name": "GWAS (custom color)",
+      "category": ["Annotation"],
+      "assemblyNames": ["hg19"],
+      "adapter": {
+        "type": "BedTabixAdapter",
+        "scoreColumn": "neg_log_pvalue",
+        "bedGzLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/gwas/summary_stats.txt.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/gwas/summary_stats.txt.gz.tbi"
+          },
+          "indexType": "TBI"
+        }
+      },
+      "displays": [
+        {
+          "displayId": "gwas_display_custom_color",
+          "type": "LinearManhattanDisplay",
+          "renderers": {
+            "LinearManhattanRenderer": {
+              "color": "green"
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/src/LinearManhattanDisplay/configSchemaFactory.ts
+++ b/src/LinearManhattanDisplay/configSchemaFactory.ts
@@ -9,6 +9,9 @@ export function configSchemaFactory(pluginManager: PluginManager) {
   //@ts-ignore
   const { baseLinearDisplayConfigSchema } = LGVPlugin.exports;
 
+  const LinearManhattanRendererConfigSchema = pluginManager.getRendererType(
+    "LinearManhattanRenderer",
+  ).configSchema;
   return ConfigurationSchema(
     "LinearManhattanDisplay",
     {
@@ -58,6 +61,9 @@ export function configSchemaFactory(pluginManager: PluginManager) {
         model: types.enumeration("Rendering", ["density", "xyplot", "line"]),
         defaultValue: "xyplot",
       },
+      renderers: ConfigurationSchema("RenderersConfiguration", {
+        LinearManhattanRenderer: LinearManhattanRendererConfigSchema,
+      }),
     },
     { baseConfiguration: baseLinearDisplayConfigSchema, explicitlyTyped: true },
   );

--- a/src/LinearManhattanRenderer/index.ts
+++ b/src/LinearManhattanRenderer/index.ts
@@ -1,5 +1,5 @@
-export { default } from "./LinearManhattanRenderer";
 import { ConfigurationSchema } from "@jbrowse/core/configuration";
+export { default } from "./LinearManhattanRenderer";
 
 export const configSchema = ConfigurationSchema(
   "LinearManhattanRenderer",


### PR DESCRIPTION
Was not passing a renderer config to the backend without this change